### PR TITLE
Fixes header not being visible after config change

### DIFF
--- a/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyHeaderPositioner.java
+++ b/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyHeaderPositioner.java
@@ -122,6 +122,7 @@ final class StickyHeaderPositioner {
                             //noinspection deprecation
                             currentHeader.getViewTreeObserver().removeGlobalOnLayoutListener(this);
                         }
+                        stickyHeaderHandler.getRecyclerParent().requestLayout();
                         checkHeaderPositions(visibleHeaders);
                     }
                 });

--- a/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyHeaderPositioner.java
+++ b/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyHeaderPositioner.java
@@ -147,8 +147,11 @@ final class StickyHeaderPositioner {
         }
     }
 
-    void reset(int orientation) {
+    void reset(int orientation, int firstVisiblePosition) {
         this.orientation = orientation;
+        // Don't reset/detach if we are going to reattach the same header
+        if (getHeaderPositionToShow(firstVisiblePosition) == lastBoundPosition) return;
+
         dirty = true;
         safeDetachHeader();
         lastBoundPosition = INVALID_POSITION;

--- a/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyLayoutManager.java
+++ b/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyLayoutManager.java
@@ -38,7 +38,7 @@ public class StickyLayoutManager extends LinearLayoutManager {
     public void onLayoutChildren(RecyclerView.Recycler recycler, RecyclerView.State state) {
         super.onLayoutChildren(recycler, state);
         cacheHeaderPositions();
-        positioner.reset(getOrientation());
+        positioner.reset(getOrientation(), findFirstVisibleItemPosition());
         positioner.updateHeaderState(findFirstVisibleItemPosition(), recycler);
         positioner.checkHeaderPositions(getVisibleHeaders());
     }


### PR DESCRIPTION
Possible solution to #1 

Only issue now is flickering if Header is bound and an item gets removed. Should look into a smarter way of resetting state. If the next header to be bound after a layout is the same header that is currently bound, we should avoid detaching it.