### PR TITLE
Concept for supporting padding/clipToPadding=false

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,13 +22,13 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':stickyheaders')
-    compile 'com.android.support:appcompat-v7:24.0.0'
-    compile 'com.android.support:recyclerview-v7:24.0.0'
+    compile "com.android.support:appcompat-v7:$supportLibraryVersion"
+    compile "com.android.support:recyclerview-v7:$supportLibraryVersion"
 
     testCompile 'junit:junit:4.12'
 
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
-    androidTestCompile 'com.android.support:support-annotations:24.0.0'
+    androidTestCompile "com.android.support:support-annotations:$supportLibraryVersion"
     androidTestCompile('com.android.support.test.espresso:espresso-contrib:2.2.2', {
         exclude module: 'support-annotations'
         exclude module: 'support-v4'

--- a/app/src/main/java/com/brandongogetap/stickyheaders/demo/MainActivity.java
+++ b/app/src/main/java/com/brandongogetap/stickyheaders/demo/MainActivity.java
@@ -3,11 +3,9 @@ package com.brandongogetap.stickyheaders.demo;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.RecyclerView;
-import android.view.ViewGroup;
-import android.widget.FrameLayout;
 
-import com.brandongogetap.stickyheaders.exposed.StickyHeaderHandler;
 import com.brandongogetap.stickyheaders.StickyLayoutManager;
+import com.brandongogetap.stickyheaders.exposed.StickyHeaderHandler;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,15 +13,14 @@ import java.util.List;
 public class MainActivity extends AppCompatActivity implements StickyHeaderHandler {
 
     private List<Item> items;
-    private FrameLayout recyclerParent;
+    private RecyclerView recyclerView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        RecyclerView recyclerView = (RecyclerView) findViewById(R.id.recycler_view);
-        recyclerParent = (FrameLayout) findViewById(R.id.fl_parent);
+        recyclerView = (RecyclerView) findViewById(R.id.recycler_view);
 
         items = compileItems();
         RecyclerAdapter adapter = new RecyclerAdapter(items);
@@ -48,7 +45,7 @@ public class MainActivity extends AppCompatActivity implements StickyHeaderHandl
         return items;
     }
 
-    @Override public ViewGroup getRecyclerParent() {
-        return recyclerParent;
+    @Override public RecyclerView getRecyclerView() {
+        return recyclerView;
     }
 }

--- a/app/src/main/java/com/brandongogetap/stickyheaders/demo/MainActivity.java
+++ b/app/src/main/java/com/brandongogetap/stickyheaders/demo/MainActivity.java
@@ -13,14 +13,13 @@ import java.util.List;
 public class MainActivity extends AppCompatActivity implements StickyHeaderHandler {
 
     private List<Item> items;
-    private RecyclerView recyclerView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        recyclerView = (RecyclerView) findViewById(R.id.recycler_view);
+        RecyclerView recyclerView = (RecyclerView) findViewById(R.id.recycler_view);
 
         items = compileItems();
         RecyclerAdapter adapter = new RecyclerAdapter(items);
@@ -43,9 +42,5 @@ public class MainActivity extends AppCompatActivity implements StickyHeaderHandl
 
     @Override public List<?> getAdapterData() {
         return items;
-    }
-
-    @Override public RecyclerView getRecyclerView() {
-        return recyclerView;
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout
-    android:id="@+id/fl_parent"
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -8,5 +7,7 @@
     <android.support.v7.widget.RecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:padding="10dp"/>
 </FrameLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -25,4 +25,5 @@ task clean(type: Delete) {
 
 ext {
     mockitoVersion = '1.10.19'
+    supportLibraryVersion = '24.1.1'
 }

--- a/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/Preconditions.java
+++ b/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/Preconditions.java
@@ -20,7 +20,7 @@ final class Preconditions {
     }
 
     static void validateParentView(StickyHeaderHandler headerHandler) {
-        View parentView = headerHandler.getRecyclerParent();
+        View parentView = (View) headerHandler.getRecyclerView().getParent();
         if (!(parentView instanceof FrameLayout) && !(parentView instanceof CoordinatorLayout)) {
             throw new IllegalArgumentException("RecyclerView parent must be either a FrameLayout or CoordinatorLayout");
         }

--- a/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/Preconditions.java
+++ b/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/Preconditions.java
@@ -4,8 +4,6 @@ import android.support.design.widget.CoordinatorLayout;
 import android.view.View;
 import android.widget.FrameLayout;
 
-import com.brandongogetap.stickyheaders.exposed.StickyHeaderHandler;
-
 final class Preconditions {
 
     private Preconditions() {
@@ -19,8 +17,8 @@ final class Preconditions {
         return item;
     }
 
-    static void validateParentView(StickyHeaderHandler headerHandler) {
-        View parentView = (View) headerHandler.getRecyclerView().getParent();
+    static void validateParentView(View recyclerView) {
+        View parentView = (View) recyclerView.getParent();
         if (!(parentView instanceof FrameLayout) && !(parentView instanceof CoordinatorLayout)) {
             throw new IllegalArgumentException("RecyclerView parent must be either a FrameLayout or CoordinatorLayout");
         }

--- a/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyHeaderPositioner.java
+++ b/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyHeaderPositioner.java
@@ -80,9 +80,9 @@ final class StickyHeaderPositioner {
             if (offsetHeader(nextHeader) == -1) {
                 resetTranslation();
             }
-            currentHeader.setVisibility(View.VISIBLE);
             break;
         }
+        currentHeader.setVisibility(View.VISIBLE);
     }
 
     private float offsetHeader(View nextHeader) {
@@ -129,7 +129,7 @@ final class StickyHeaderPositioner {
      */
     private int getHeaderPositionToShow(int firstVisiblePosition, @Nullable View headerForPosition) {
         int headerPositionToShow = INVALID_POSITION;
-        if (headerForPosition != null && headerForPosition.getY() > 0) {
+        if (headerIsOffset(headerForPosition)) {
             int offsetHeaderIndex = headerPositions.indexOf(firstVisiblePosition);
             if (offsetHeaderIndex > 0) {
                 return headerPositions.get(offsetHeaderIndex - 1);
@@ -143,6 +143,14 @@ final class StickyHeaderPositioner {
             }
         }
         return headerPositionToShow;
+    }
+
+    private boolean headerIsOffset(View headerForPosition) {
+        if (headerForPosition != null) {
+            return orientation == LinearLayoutManager.VERTICAL ?
+                    headerForPosition.getY() > 0 : headerForPosition.getX() > 0;
+        }
+        return false;
     }
 
     private void attachHeader(View view) {

--- a/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyHeaderPositioner.java
+++ b/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyHeaderPositioner.java
@@ -5,12 +5,11 @@ import android.support.annotation.Nullable;
 import android.support.annotation.Px;
 import android.support.annotation.VisibleForTesting;
 import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewGroup.MarginLayoutParams;
 import android.view.ViewTreeObserver;
-
-import com.brandongogetap.stickyheaders.exposed.StickyHeaderHandler;
 
 import java.util.List;
 import java.util.Map;
@@ -19,7 +18,7 @@ final class StickyHeaderPositioner {
 
     private static final int INVALID_POSITION = -1;
 
-    private final StickyHeaderHandler stickyHeaderHandler;
+    private final RecyclerView recyclerView;
 
     private View currentHeader;
     private int lastBoundPosition = INVALID_POSITION;
@@ -28,8 +27,8 @@ final class StickyHeaderPositioner {
     private boolean dirty;
     private final boolean checkMargins;
 
-    StickyHeaderPositioner(StickyHeaderHandler stickyHeaderHandler) {
-        this.stickyHeaderHandler = stickyHeaderHandler;
+    StickyHeaderPositioner(RecyclerView recyclerView) {
+        this.recyclerView = recyclerView;
         checkMargins = recyclerViewHasPadding();
     }
 
@@ -184,11 +183,11 @@ final class StickyHeaderPositioner {
 
     private void matchMarginsToPadding(MarginLayoutParams layoutParams) {
         @Px int leftMargin = orientation == LinearLayoutManager.VERTICAL ?
-                stickyHeaderHandler.getRecyclerView().getPaddingLeft() : 0;
+                recyclerView.getPaddingLeft() : 0;
         @Px int topMargin = orientation == LinearLayoutManager.VERTICAL ?
-                0 : stickyHeaderHandler.getRecyclerView().getPaddingTop();
+                0 : recyclerView.getPaddingTop();
         @Px int rightMargin = orientation == LinearLayoutManager.VERTICAL ?
-                stickyHeaderHandler.getRecyclerView().getPaddingRight() : 0;
+                recyclerView.getPaddingRight() : 0;
         layoutParams.setMargins(leftMargin, topMargin, rightMargin, 0);
     }
 
@@ -211,12 +210,13 @@ final class StickyHeaderPositioner {
     }
 
     private boolean recyclerViewHasPadding() {
-        View view = stickyHeaderHandler.getRecyclerView();
-        return view.getPaddingLeft() > 0 || view.getPaddingRight() > 0 || view.getPaddingTop() > 0;
+        return recyclerView.getPaddingLeft() > 0
+                || recyclerView.getPaddingRight() > 0
+                || recyclerView.getPaddingTop() > 0;
     }
 
     private ViewGroup getRecyclerParent() {
-        return (ViewGroup) stickyHeaderHandler.getRecyclerView().getParent();
+        return (ViewGroup) recyclerView.getParent();
     }
 
     private void waitForLayoutAndRetry(final Map<Integer, View> visibleHeaders) {

--- a/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyLayoutManager.java
+++ b/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyLayoutManager.java
@@ -45,9 +45,8 @@ public class StickyLayoutManager extends LinearLayoutManager {
         super.onLayoutChildren(recycler, state);
         cacheHeaderPositions();
         positioner.reset(getOrientation(), findFirstVisibleItemPosition());
-        positioner.updateHeaderState(
-                findFirstVisibleItemPosition(), viewRetriever.setRecycler(recycler));
-        positioner.checkHeaderPositions(getVisibleHeaders());
+        positioner.updateHeaderState(findFirstVisibleItemPosition(), getVisibleHeaders(),
+                viewRetriever.setRecycler(recycler));
     }
 
     private void cacheHeaderPositions() {
@@ -64,9 +63,18 @@ public class StickyLayoutManager extends LinearLayoutManager {
     public int scrollVerticallyBy(int dy, RecyclerView.Recycler recycler, RecyclerView.State state) {
         int scroll = super.scrollVerticallyBy(dy, recycler, state);
         if (Math.abs(scroll) > 0) {
-            positioner.updateHeaderState(
-                    findFirstVisibleItemPosition(), viewRetriever.setRecycler(recycler));
-            positioner.checkHeaderPositions(getVisibleHeaders());
+            positioner.updateHeaderState(findFirstVisibleItemPosition(), getVisibleHeaders(),
+                    viewRetriever.setRecycler(recycler));
+        }
+        return scroll;
+    }
+
+    @Override
+    public int scrollHorizontallyBy(int dx, RecyclerView.Recycler recycler, RecyclerView.State state) {
+        int scroll = super.scrollHorizontallyBy(dx, recycler, state);
+        if (Math.abs(scroll) > 0) {
+            positioner.updateHeaderState(findFirstVisibleItemPosition(), getVisibleHeaders(),
+                    viewRetriever.setRecycler(recycler));
         }
         return scroll;
     }
@@ -82,16 +90,5 @@ public class StickyLayoutManager extends LinearLayoutManager {
             }
         }
         return visibleHeaders;
-    }
-
-    @Override
-    public int scrollHorizontallyBy(int dx, RecyclerView.Recycler recycler, RecyclerView.State state) {
-        int scroll = super.scrollHorizontallyBy(dx, recycler, state);
-        if (Math.abs(scroll) > 0) {
-            positioner.updateHeaderState(
-                    findFirstVisibleItemPosition(), viewRetriever.setRecycler(recycler));
-            positioner.checkHeaderPositions(getVisibleHeaders());
-        }
-        return scroll;
     }
 }

--- a/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyLayoutManager.java
+++ b/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyLayoutManager.java
@@ -20,6 +20,7 @@ public class StickyLayoutManager extends LinearLayoutManager {
     private StickyHeaderHandler headerHandler;
     private List<Integer> headerPositions;
     private RecyclerViewRetriever viewRetriever;
+    private RecyclerView recyclerView;
 
     public StickyLayoutManager(Context context, StickyHeaderHandler headerHandler) {
         this(context, VERTICAL, false, headerHandler);
@@ -33,9 +34,7 @@ public class StickyLayoutManager extends LinearLayoutManager {
 
     private void setStickyHeaderHandler(StickyHeaderHandler headerHandler) {
         Preconditions.checkNotNull(headerHandler, "StickyHeaderHandler == null");
-        Preconditions.validateParentView(headerHandler);
         this.headerHandler = headerHandler;
-        positioner = new StickyHeaderPositioner(headerHandler);
         headerPositions = new ArrayList<>();
         viewRetriever = new RecyclerViewRetriever();
     }
@@ -90,5 +89,12 @@ public class StickyLayoutManager extends LinearLayoutManager {
             }
         }
         return visibleHeaders;
+    }
+
+    @Override public void onAttachedToWindow(RecyclerView view) {
+        super.onAttachedToWindow(view);
+        recyclerView = view;
+        Preconditions.validateParentView(recyclerView);
+        positioner = new StickyHeaderPositioner(recyclerView);
     }
 }

--- a/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/exposed/StickyHeaderHandler.java
+++ b/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/exposed/StickyHeaderHandler.java
@@ -1,7 +1,6 @@
 package com.brandongogetap.stickyheaders.exposed;
 
 import android.support.v7.widget.RecyclerView;
-import android.widget.LinearLayout;
 
 import java.util.List;
 
@@ -11,15 +10,4 @@ public interface StickyHeaderHandler {
      * @return The dataset supplied to the {@link RecyclerView.Adapter}
      */
     List<?> getAdapterData();
-
-    /**
-     * <p>
-     * This RecyclerView must have a parent that is either a FrameLayout or CoordinatorLayout,
-     * otherwise an {@link IllegalArgumentException} will be thrown.
-     * <p>
-     * This is required because the sticky view will be added to the parent ViewGroup, so any sort
-     * of automated child layout behavior (such as linear stacking from a {@link LinearLayout} would
-     * disrupt the desired position of the header view.
-     */
-    RecyclerView getRecyclerView();
 }

--- a/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/exposed/StickyHeaderHandler.java
+++ b/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/exposed/StickyHeaderHandler.java
@@ -1,7 +1,6 @@
 package com.brandongogetap.stickyheaders.exposed;
 
 import android.support.v7.widget.RecyclerView;
-import android.view.ViewGroup;
 import android.widget.LinearLayout;
 
 import java.util.List;
@@ -14,16 +13,13 @@ public interface StickyHeaderHandler {
     List<?> getAdapterData();
 
     /**
-     * The {@link ViewGroup} hosting the {@link RecyclerView}.
      * <p>
-     * This ViewGroup must be a FrameLayout or CoordinatorLayout, otherwise an
-     * {@link IllegalArgumentException} will be thrown.
+     * This RecyclerView must have a parent that is either a FrameLayout or CoordinatorLayout,
+     * otherwise an {@link IllegalArgumentException} will be thrown.
      * <p>
-     * This is required because the sticky view will be added to this ViewGroup, so any sort of
-     * automated child layout behavior (such as linear stacking from a {@link LinearLayout} would
+     * This is required because the sticky view will be added to the parent ViewGroup, so any sort
+     * of automated child layout behavior (such as linear stacking from a {@link LinearLayout} would
      * disrupt the desired position of the header view.
-     *
-     * @return The {@link ViewGroup} hosting the {@link RecyclerView}
      */
-    ViewGroup getRecyclerParent();
+    RecyclerView getRecyclerView();
 }

--- a/stickyheaders/src/test/java/com/brandongogetap/stickyheaders/StickyHeaderPositionerRobot.java
+++ b/stickyheaders/src/test/java/com/brandongogetap/stickyheaders/StickyHeaderPositionerRobot.java
@@ -1,13 +1,13 @@
 package com.brandongogetap.stickyheaders;
 
 import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
-import android.widget.FrameLayout;
-
-import com.brandongogetap.stickyheaders.exposed.StickyHeaderHandler;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,10 +25,11 @@ final class StickyHeaderPositionerRobot {
     private View currentHeader;
 
     private StickyHeaderPositionerRobot() {
-        StickyHeaderHandler headerHandler = mock(StickyHeaderHandler.class);
-        when(headerHandler.getRecyclerParent()).thenReturn(mock(FrameLayout.class));
-        when(headerHandler.getRecyclerParent().getViewTreeObserver()).thenReturn(mock(ViewTreeObserver.class));
-        positioner = new StickyHeaderPositioner(headerHandler);
+        RecyclerView recyclerView = mock(RecyclerView.class);
+        ViewGroup parent = mock(ViewGroup.class);
+        when(recyclerView.getParent()).thenReturn(parent);
+        when(parent.getViewTreeObserver()).thenReturn(mock(ViewTreeObserver.class));
+        positioner = new StickyHeaderPositioner(recyclerView);
         positioner.setHeaderPositions(new ArrayList<Integer>());
         positioner.reset(LinearLayoutManager.VERTICAL, 0);
     }
@@ -47,7 +48,7 @@ final class StickyHeaderPositionerRobot {
         currentHeader = mock(View.class);
         when(currentHeader.getHeight()).thenReturn(200);
         when(viewRetriever.getViewForPosition(anyInt())).thenReturn(currentHeader);
-        positioner.updateHeaderState(firstVisiblePosition, viewRetriever);
+        positioner.updateHeaderState(firstVisiblePosition, Collections.<Integer, View>emptyMap(), viewRetriever);
         return this;
     }
 


### PR DESCRIPTION
Here's a potential fix for #7 

This will allow sticky headers with correct margins (to match RecyclerView padding), as well as sticking to top of parent if clipToPadding = false is set on the RecyclerView.

Supporting top padding with clipToPadding = true is probably possible, but I'm not sure it's worth looking into. If you don't want the child views to be visible behind the top padding, using top margin is an acceptable solution.

Currently horizontal orientation is broken with these changes.