### PR TITLE
Add header elevation option

### DIFF
--- a/app/src/main/java/com/brandongogetap/stickyheaders/demo/MainActivity.java
+++ b/app/src/main/java/com/brandongogetap/stickyheaders/demo/MainActivity.java
@@ -24,7 +24,9 @@ public class MainActivity extends AppCompatActivity implements StickyHeaderHandl
         items = compileItems();
         RecyclerAdapter adapter = new RecyclerAdapter(items);
         StickyLayoutManager layoutManager = new StickyLayoutManager(this, this);
-        layoutManager.elevateHeaders(true);
+        layoutManager.elevateHeaders(true); // Default elevation of 5dp
+        // You can also specify a specific dp for elevation
+//        layoutManager.elevateHeaders(10);
         recyclerView.setLayoutManager(layoutManager);
         recyclerView.setAdapter(adapter);
     }

--- a/app/src/main/java/com/brandongogetap/stickyheaders/demo/MainActivity.java
+++ b/app/src/main/java/com/brandongogetap/stickyheaders/demo/MainActivity.java
@@ -24,6 +24,7 @@ public class MainActivity extends AppCompatActivity implements StickyHeaderHandl
         items = compileItems();
         RecyclerAdapter adapter = new RecyclerAdapter(items);
         StickyLayoutManager layoutManager = new StickyLayoutManager(this, this);
+        layoutManager.elevateHeaders(true);
         recyclerView.setLayoutManager(layoutManager);
         recyclerView.setAdapter(adapter);
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-PROJECT_VERSION=0.2.0
+PROJECT_VERSION=0.3.0
 PROJECT_GROUP_ID=com.brandongogetap
 PROJECT_VCS_URL=https://github.com/bgogetap/StickyHeaders.git
 PROJECT_DESCRIPTION=StickyHeaders - Easy way to add sticky headers to RecyclerView

--- a/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyHeaderPositioner.java
+++ b/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyHeaderPositioner.java
@@ -4,6 +4,7 @@ import android.os.Build;
 import android.support.annotation.Nullable;
 import android.support.annotation.Px;
 import android.support.annotation.VisibleForTesting;
+import android.support.v4.view.ViewCompat;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
@@ -19,13 +20,15 @@ final class StickyHeaderPositioner {
     private static final int INVALID_POSITION = -1;
 
     private final RecyclerView recyclerView;
+    private final boolean checkMargins;
 
     private View currentHeader;
     private int lastBoundPosition = INVALID_POSITION;
     private List<Integer> headerPositions;
     private int orientation;
     private boolean dirty;
-    private final boolean checkMargins;
+    private boolean elevateHeaders;
+    private float cachedElevation = Float.MIN_VALUE;
 
     StickyHeaderPositioner(RecyclerView recyclerView) {
         this.recyclerView = recyclerView;
@@ -162,11 +165,22 @@ final class StickyHeaderPositioner {
         // Set to Invisible until we position it in #checkHeaderPositions.
         currentHeader.setVisibility(View.INVISIBLE);
         currentHeader.setId(R.id.header_view);
+        checkElevation(currentHeader);
         getRecyclerParent().addView(currentHeader);
         if (checkMargins) {
             updateLayoutParams(currentHeader);
         }
         dirty = false;
+    }
+
+    private void checkElevation(View currentHeader) {
+        if (elevateHeaders) {
+            if (cachedElevation == Float.MIN_VALUE) {
+                cachedElevation = currentHeader.getContext().getResources()
+                        .getDimension(R.dimen.default_elevation);
+            }
+            ViewCompat.setElevation(currentHeader, cachedElevation);
+        }
     }
 
     private void detachHeader() {
@@ -271,5 +285,9 @@ final class StickyHeaderPositioner {
 
     @VisibleForTesting int getLastBoundPosition() {
         return lastBoundPosition;
+    }
+
+    void setElevateHeaders(boolean elevateHeaders) {
+        this.elevateHeaders = elevateHeaders;
     }
 }

--- a/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyLayoutManager.java
+++ b/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyLayoutManager.java
@@ -21,15 +21,27 @@ public class StickyLayoutManager extends LinearLayoutManager {
     private List<Integer> headerPositions;
     private RecyclerViewRetriever viewRetriever;
     private RecyclerView recyclerView;
+    private boolean elevateHeaders;
 
     public StickyLayoutManager(Context context, StickyHeaderHandler headerHandler) {
         this(context, VERTICAL, false, headerHandler);
-        setStickyHeaderHandler(headerHandler);
+        init(headerHandler);
     }
 
     public StickyLayoutManager(Context context, int orientation, boolean reverseLayout, StickyHeaderHandler headerHandler) {
         super(context, orientation, reverseLayout);
-        setStickyHeaderHandler(headerHandler);
+        init(headerHandler);
+    }
+
+    private void init(StickyHeaderHandler stickyHeaderHandler) {
+        setStickyHeaderHandler(stickyHeaderHandler);
+    }
+
+    public void elevateHeaders(boolean elevateHeaders) {
+        this.elevateHeaders = elevateHeaders;
+        if (positioner != null) {
+            positioner.setElevateHeaders(elevateHeaders);
+        }
     }
 
     private void setStickyHeaderHandler(StickyHeaderHandler headerHandler) {
@@ -96,5 +108,6 @@ public class StickyLayoutManager extends LinearLayoutManager {
         recyclerView = view;
         Preconditions.validateParentView(recyclerView);
         positioner = new StickyHeaderPositioner(recyclerView);
+        positioner.setElevateHeaders(elevateHeaders);
     }
 }

--- a/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyLayoutManager.java
+++ b/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyLayoutManager.java
@@ -21,7 +21,7 @@ public class StickyLayoutManager extends LinearLayoutManager {
     private List<Integer> headerPositions;
     private RecyclerViewRetriever viewRetriever;
     private RecyclerView recyclerView;
-    private boolean elevateHeaders;
+    private int headerElevation;
 
     public StickyLayoutManager(Context context, StickyHeaderHandler headerHandler) {
         this(context, VERTICAL, false, headerHandler);
@@ -37,10 +37,29 @@ public class StickyLayoutManager extends LinearLayoutManager {
         setStickyHeaderHandler(stickyHeaderHandler);
     }
 
+    /**
+     * Enable or disable elevation for Sticky Headers.
+     * <p>
+     * If you want to specify a specific amount of elevation, use
+     * {@link StickyLayoutManager#elevateHeaders(int)}
+     *
+     * @param elevateHeaders Enable Sticky Header elevation. Default is false.
+     */
     public void elevateHeaders(boolean elevateHeaders) {
-        this.elevateHeaders = elevateHeaders;
+        this.headerElevation = elevateHeaders ?
+                StickyHeaderPositioner.DEFAULT_ELEVATION : StickyHeaderPositioner.NO_ELEVATION;
+        elevateHeaders(headerElevation);
+    }
+
+    /**
+     * Enable Sticky Header elevation with a specific amount.
+     *
+     * @param dp elevation in dp
+     */
+    public void elevateHeaders(int dp) {
+        this.headerElevation = dp;
         if (positioner != null) {
-            positioner.setElevateHeaders(elevateHeaders);
+            positioner.setElevateHeaders(dp);
         }
     }
 
@@ -108,6 +127,6 @@ public class StickyLayoutManager extends LinearLayoutManager {
         recyclerView = view;
         Preconditions.validateParentView(recyclerView);
         positioner = new StickyHeaderPositioner(recyclerView);
-        positioner.setElevateHeaders(elevateHeaders);
+        positioner.setElevateHeaders(headerElevation);
     }
 }

--- a/stickyheaders/src/main/res/values/dimens.xml
+++ b/stickyheaders/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="default_elevation">5dp</dimen>
+</resources>


### PR DESCRIPTION
Possible solution for #13 

When another header is displacing a current one, the elevation difference looks a bit off. Maybe elevation should be reset if a header is being displaced? That doesn't look quite right either.