### PR TITLE
Change how views are retrieved for headers

### DIFF
--- a/app/src/main/java/com/brandongogetap/stickyheaders/demo/RecyclerAdapter.java
+++ b/app/src/main/java/com/brandongogetap/stickyheaders/demo/RecyclerAdapter.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 import static android.view.LayoutInflater.from;
 
-final class RecyclerAdapter extends RecyclerView.Adapter<RecyclerAdapter.MyViewHolder> {
+final class RecyclerAdapter extends RecyclerView.Adapter<RecyclerAdapter.BaseViewHolder> {
 
     private final List<Item> data;
 
@@ -21,23 +21,27 @@ final class RecyclerAdapter extends RecyclerView.Adapter<RecyclerAdapter.MyViewH
     }
 
     @Override
-    public MyViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+    public BaseViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View view = from(parent.getContext()).inflate(R.layout.item_view, parent, false);
-        final MyViewHolder holder = new MyViewHolder(view);
+        final BaseViewHolder viewHolder;
+        if (viewType == 0) {
+            viewHolder = new MyViewHolder(view);
+        } else {
+            viewHolder = new MyOtherViewHolder(view);
+        }
         view.setOnClickListener(new View.OnClickListener() {
             @Override public void onClick(View v) {
                 // This is unsafe to do in OnClickListeners attached to sticky headers. The adapter
                 // position of the holder will be out of sync if any items have been added/removed.
-                int position = holder.getAdapterPosition();
-
+                int position = viewHolder.getAdapterPosition();
                 data.remove(position);
                 notifyDataSetChanged();
             }
         });
-        return holder;
+        return viewHolder;
     }
 
-    @Override public void onBindViewHolder(MyViewHolder holder, int position) {
+    @Override public void onBindViewHolder(BaseViewHolder holder, int position) {
         Item item = data.get(position);
         holder.titleTextView.setText(item.title);
         holder.messageTextView.setText(item.message);
@@ -57,12 +61,33 @@ final class RecyclerAdapter extends RecyclerView.Adapter<RecyclerAdapter.MyViewH
         return data.size();
     }
 
-    static final class MyViewHolder extends RecyclerView.ViewHolder {
+    @Override public int getItemViewType(int position) {
+        if (position != 0 && position % 16 == 0) {
+            return 1;
+        }
+        return 0;
+    }
+
+    private static final class MyViewHolder extends BaseViewHolder {
+
+        MyViewHolder(View itemView) {
+            super(itemView);
+        }
+    }
+
+    private static final class MyOtherViewHolder extends BaseViewHolder {
+
+        MyOtherViewHolder(View itemView) {
+            super(itemView);
+        }
+    }
+
+    static class BaseViewHolder extends RecyclerView.ViewHolder {
 
         TextView titleTextView;
         TextView messageTextView;
 
-        MyViewHolder(View itemView) {
+        BaseViewHolder(View itemView) {
             super(itemView);
             titleTextView = (TextView) itemView.findViewById(R.id.tv_title);
             messageTextView = (TextView) itemView.findViewById(R.id.tv_message);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-PROJECT_VERSION=0.3.1
+PROJECT_VERSION=0.3.2
 PROJECT_GROUP_ID=com.brandongogetap
 PROJECT_VCS_URL=https://github.com/bgogetap/StickyHeaders.git
 PROJECT_DESCRIPTION=StickyHeaders - Easy way to add sticky headers to RecyclerView

--- a/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyLayoutManager.java
+++ b/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyLayoutManager.java
@@ -67,7 +67,6 @@ public class StickyLayoutManager extends LinearLayoutManager {
         Preconditions.checkNotNull(headerHandler, "StickyHeaderHandler == null");
         this.headerHandler = headerHandler;
         headerPositions = new ArrayList<>();
-        viewRetriever = new RecyclerViewRetriever();
     }
 
     @Override
@@ -75,8 +74,8 @@ public class StickyLayoutManager extends LinearLayoutManager {
         super.onLayoutChildren(recycler, state);
         cacheHeaderPositions();
         positioner.reset(getOrientation(), findFirstVisibleItemPosition());
-        positioner.updateHeaderState(findFirstVisibleItemPosition(), getVisibleHeaders(),
-                viewRetriever.setRecycler(recycler));
+        positioner.updateHeaderState(
+                findFirstVisibleItemPosition(), getVisibleHeaders(), viewRetriever);
     }
 
     private void cacheHeaderPositions() {
@@ -93,8 +92,8 @@ public class StickyLayoutManager extends LinearLayoutManager {
     public int scrollVerticallyBy(int dy, RecyclerView.Recycler recycler, RecyclerView.State state) {
         int scroll = super.scrollVerticallyBy(dy, recycler, state);
         if (Math.abs(scroll) > 0) {
-            positioner.updateHeaderState(findFirstVisibleItemPosition(), getVisibleHeaders(),
-                    viewRetriever.setRecycler(recycler));
+            positioner.updateHeaderState(
+                    findFirstVisibleItemPosition(), getVisibleHeaders(), viewRetriever);
         }
         return scroll;
     }
@@ -103,8 +102,8 @@ public class StickyLayoutManager extends LinearLayoutManager {
     public int scrollHorizontallyBy(int dx, RecyclerView.Recycler recycler, RecyclerView.State state) {
         int scroll = super.scrollHorizontallyBy(dx, recycler, state);
         if (Math.abs(scroll) > 0) {
-            positioner.updateHeaderState(findFirstVisibleItemPosition(), getVisibleHeaders(),
-                    viewRetriever.setRecycler(recycler));
+            positioner.updateHeaderState(
+                    findFirstVisibleItemPosition(), getVisibleHeaders(), viewRetriever);
         }
         return scroll;
     }
@@ -126,6 +125,7 @@ public class StickyLayoutManager extends LinearLayoutManager {
         super.onAttachedToWindow(view);
         recyclerView = view;
         Preconditions.validateParentView(recyclerView);
+        viewRetriever = new RecyclerViewRetriever(recyclerView);
         positioner = new StickyHeaderPositioner(recyclerView);
         positioner.setElevateHeaders(headerElevation);
     }

--- a/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/ViewRetriever.java
+++ b/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/ViewRetriever.java
@@ -1,28 +1,32 @@
 package com.brandongogetap.stickyheaders;
 
 import android.support.v7.widget.RecyclerView;
-import android.view.View;
+import android.view.ViewGroup;
 
 interface ViewRetriever {
 
-    View getViewForPosition(int position);
+    RecyclerView.ViewHolder getViewHolderForPosition(int headerPositionToShow);
 
     final class RecyclerViewRetriever implements ViewRetriever {
 
-        private RecyclerView.Recycler recycler;
+        private final RecyclerView recyclerView;
 
-        RecyclerViewRetriever() {
+        private RecyclerView.ViewHolder currentViewHolder;
+        private int currentViewType;
+
+        RecyclerViewRetriever(RecyclerView recyclerView) {
+            this.recyclerView = recyclerView;
+            this.currentViewType = -1;
         }
 
-        RecyclerViewRetriever setRecycler(RecyclerView.Recycler recycler) {
-            this.recycler = recycler;
-            return this;
-        }
-
-        @Override public View getViewForPosition(int position) {
-            View view = recycler.getViewForPosition(position);
-            recycler = null;
-            return view;
+        @Override
+        public RecyclerView.ViewHolder getViewHolderForPosition(int position) {
+            if (currentViewType != recyclerView.getAdapter().getItemViewType(position)) {
+                currentViewType = recyclerView.getAdapter().getItemViewType(position);
+                currentViewHolder = recyclerView.getAdapter().createViewHolder(
+                        (ViewGroup) recyclerView.getParent(), currentViewType);
+            }
+            return currentViewHolder;
         }
     }
 }

--- a/stickyheaders/src/test/java/com/brandongogetap/stickyheaders/StickyHeaderPositionerRobot.java
+++ b/stickyheaders/src/test/java/com/brandongogetap/stickyheaders/StickyHeaderPositionerRobot.java
@@ -22,16 +22,26 @@ import static org.mockito.Mockito.when;
 final class StickyHeaderPositionerRobot {
 
     private final StickyHeaderPositioner positioner;
+
+    private RecyclerView.ViewHolder viewHolder;
     private View currentHeader;
 
     private StickyHeaderPositionerRobot() {
         RecyclerView recyclerView = mock(RecyclerView.class);
         ViewGroup parent = mock(ViewGroup.class);
         when(recyclerView.getParent()).thenReturn(parent);
+        when(recyclerView.getAdapter()).thenReturn(mock(RecyclerView.Adapter.class));
         when(parent.getViewTreeObserver()).thenReturn(mock(ViewTreeObserver.class));
         positioner = new StickyHeaderPositioner(recyclerView);
         positioner.setHeaderPositions(new ArrayList<Integer>());
         positioner.reset(LinearLayoutManager.VERTICAL, 0);
+
+        currentHeader = mock(View.class);
+        viewHolder = new RecyclerView.ViewHolder(currentHeader) {
+            @Override public String toString() {
+                return super.toString();
+            }
+        };
     }
 
     static StickyHeaderPositionerRobot create() {
@@ -45,9 +55,8 @@ final class StickyHeaderPositionerRobot {
 
     StickyHeaderPositionerRobot setupPosition(int firstVisiblePosition) {
         ViewRetriever viewRetriever = mock(ViewRetriever.class);
-        currentHeader = mock(View.class);
         when(currentHeader.getHeight()).thenReturn(200);
-        when(viewRetriever.getViewForPosition(anyInt())).thenReturn(currentHeader);
+        when(viewRetriever.getViewHolderForPosition(anyInt())).thenReturn(viewHolder);
         positioner.updateHeaderState(firstVisiblePosition, Collections.<Integer, View>emptyMap(), viewRetriever);
         return this;
     }


### PR DESCRIPTION
Instead of requesting Views from the Recycler, I'm now creating a ViewHolder instance and holding onto it as long as the view type for the bound headers stays the same (in that case, I'm just calling onBindViewHolder so detach/attach isn't called).

There is still a small glitch when a header with a different height is scrolling in from offscreen that I want to get sorted before I merge this in.

Fixes #18