### PR TITLE
Fix sticky header not positioning correctly

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-PROJECT_VERSION=0.3.2
+PROJECT_VERSION=0.3.3
 PROJECT_GROUP_ID=com.brandongogetap
 PROJECT_VCS_URL=https://github.com/bgogetap/StickyHeaders.git
 PROJECT_DESCRIPTION=StickyHeaders - Easy way to add sticky headers to RecyclerView

--- a/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyHeaderPositioner.java
+++ b/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyHeaderPositioner.java
@@ -95,14 +95,17 @@ final class StickyHeaderPositioner {
             waitForLayoutAndRetry(visibleHeaders);
             return;
         }
+        boolean reset = false;
         for (Map.Entry<Integer, View> entry : visibleHeaders.entrySet()) {
-            if (entry.getKey() == lastBoundPosition) continue;
-            View nextHeader = entry.getValue();
-            if (offsetHeader(nextHeader) == -1) {
-                resetTranslation();
+            if (entry.getKey() == lastBoundPosition) {
+                reset = true;
+                continue;
             }
+            View nextHeader = entry.getValue();
+            reset = offsetHeader(nextHeader) == -1;
             break;
         }
+        if (reset) resetTranslation();
         currentHeader.setVisibility(View.VISIBLE);
     }
 


### PR DESCRIPTION
Translation was not reset when there were no other visible sticky headers besides the one pinned. This issue is new since in 0.3.2 I no longer detach/attach views during header changes--I just rebind the ViewHolder (if it's of the same type). Because of this, the old translation of the outgoing header was persisted.

Fixes #21 