### PR TITLE
Handle null list items in adapter

### DIFF
--- a/app/src/main/java/com/brandongogetap/stickyheaders/demo/RecyclerAdapter.java
+++ b/app/src/main/java/com/brandongogetap/stickyheaders/demo/RecyclerAdapter.java
@@ -65,7 +65,7 @@ final class RecyclerAdapter extends RecyclerView.Adapter<RecyclerAdapter.BaseVie
     }
 
     @Override public int getItemCount() {
-        return data.size();
+        return data != null ? data.size() : 0;
     }
 
     @Override public int getItemViewType(int position) {

--- a/build.gradle
+++ b/build.gradle
@@ -27,5 +27,5 @@ ext {
     compileSdkVersion = 25
     buildToolsVersion = '25.0.2'
     mockitoVersion = '1.10.19'
-    supportLibraryVersion = '25.3.0'
+    supportLibraryVersion = '25.3.1'
 }

--- a/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyLayoutManager.java
+++ b/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyLayoutManager.java
@@ -83,8 +83,14 @@ public class StickyLayoutManager extends LinearLayoutManager {
 
     private void cacheHeaderPositions() {
         headerPositions.clear();
-        for (int i = 0; i < headerHandler.getAdapterData().size(); i++) {
-            if (headerHandler.getAdapterData().get(i) instanceof StickyHeader) {
+        List<?> adapterData = headerHandler.getAdapterData();
+        if (adapterData == null) {
+            positioner.setHeaderPositions(headerPositions);
+            return;
+        }
+
+        for (int i = 0; i < adapterData.size(); i++) {
+            if (adapterData.get(i) instanceof StickyHeader) {
                 headerPositions.add(i);
             }
         }


### PR DESCRIPTION
There are scenarios when user will instantiate items in some later stage, like after sync with API. This gives flexibility to the developer to create setup of RecyclerView's in base classes and later on just provide adapter with the data.