### PR TITLE
bugfix: inconsistency

### DIFF
--- a/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyLayoutManager.java
+++ b/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyLayoutManager.java
@@ -170,4 +170,13 @@ public class StickyLayoutManager extends LinearLayoutManager {
             positioner.setHeaderPositions(headerPositions);
         }
     }
+
+    /**
+     * We override this method in order to prevent a crash.
+     * https://stackoverflow.com/questions/30220771/recyclerview-inconsistency-detected-invalid-item-position?page=1&tab=votes#tab-top
+     */
+    @Override
+    public boolean supportsPredictiveItemAnimations() {
+        return false;
+    }
 }


### PR DESCRIPTION
Thank you for this library.

Our QA has reported a crash happening in the RecyclerView internals. 

There is a post claiming there is a simple workaround:
https://stackoverflow.com/questions/30220771/recyclerview-inconsistency-detected-invalid-item-position?page=1&tab=votes#tab-top

This PR is just a simple implementation of the workaround.

