### PR TITLE
Header elevation pixels

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ That's it! See the example app for more in depth details.
 #### Additional Features
 Add elevation to your headers (animated in and out) on Lollipop and above:
 
-`layoutManager.elevateHeaders(true)` OR `layoutManager.setElevation(int dp)`
+`layoutManager.setHeaderElevation(float px)`
 
 Add a listener to be notified when headers are attached/re-bound or detached:
 

--- a/app/src/main/java/com/brandongogetap/stickyheaders/demo/MainActivity.java
+++ b/app/src/main/java/com/brandongogetap/stickyheaders/demo/MainActivity.java
@@ -1,10 +1,11 @@
 package com.brandongogetap.stickyheaders.demo;
 
 import android.os.Bundle;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.recyclerview.widget.RecyclerView;
 import android.util.Log;
 import android.view.View;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.brandongogetap.stickyheaders.StickyLayoutManager;
 import com.brandongogetap.stickyheaders.exposed.StickyHeaderListener;
@@ -27,9 +28,7 @@ public class MainActivity extends AppCompatActivity {
         adapter = new RecyclerAdapter();
         adapter.setData(ItemGenerator.demoList());
         StickyLayoutManager layoutManager = new TopSnappedStickyLayoutManager(this, adapter);
-        layoutManager.elevateHeaders(true); // Default elevation of 5dp
-        // You can also specify a specific dp for elevation
-//        layoutManager.elevateHeaders(10);
+        layoutManager.setHeaderElevation(getResources().getDimensionPixelSize(R.dimen.elevation_sticky_header));
         recyclerView.setLayoutManager(layoutManager);
         recyclerView.setAdapter(adapter);
         layoutManager.setStickyHeaderListener(new StickyHeaderListener() {

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,5 +1,3 @@
 <resources>
-    <!-- Default screen margins, per the Android Design guidelines. -->
-    <dimen name="activity_horizontal_margin">16dp</dimen>
-    <dimen name="activity_vertical_margin">16dp</dimen>
+    <dimen name="elevation_sticky_header">4dp</dimen>
 </resources>

--- a/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyLayoutManager.java
+++ b/stickyheaders/src/main/java/com/brandongogetap/stickyheaders/StickyLayoutManager.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.view.View;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.Px;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -23,7 +24,7 @@ public class StickyLayoutManager extends LinearLayoutManager {
     private StickyHeaderHandler headerHandler;
     private List<Integer> headerPositions = new ArrayList<>();
     private RecyclerViewRetriever viewRetriever;
-    private int headerElevation = StickyHeaderPositioner.NO_ELEVATION;
+    private float headerElevation = StickyHeaderPositioner.NO_ELEVATION;
     /**
      * If {@code false}, the {@link android.view.ViewParent} of this layout manager's {@link RecyclerView}
      * will not be validated against supported types.
@@ -62,28 +63,14 @@ public class StickyLayoutManager extends LinearLayoutManager {
     }
 
     /**
-     * Enable or disable elevation for Sticky Headers.
-     * <p>
-     * If you want to specify a specific amount of elevation, use
-     * {@link StickyLayoutManager#elevateHeaders(int)}
+     * Sets the elevation of the sticky header view, in pixels.
      *
-     * @param elevateHeaders Enable Sticky Header elevation. Default is false.
+     * @param elevation elevation in pixels.
      */
-    public void elevateHeaders(boolean elevateHeaders) {
-        this.headerElevation = elevateHeaders ?
-                StickyHeaderPositioner.DEFAULT_ELEVATION : StickyHeaderPositioner.NO_ELEVATION;
-        elevateHeaders(headerElevation);
-    }
-
-    /**
-     * Enable Sticky Header elevation with a specific amount.
-     *
-     * @param dp elevation in dp
-     */
-    public void elevateHeaders(int dp) {
-        this.headerElevation = dp;
+    public void setHeaderElevation(@Px float elevation) {
+        this.headerElevation = elevation;
         if (positioner != null) {
-            positioner.setElevateHeaders(dp);
+            positioner.setHeaderElevation(elevation);
         }
     }
 
@@ -146,7 +133,7 @@ public class StickyLayoutManager extends LinearLayoutManager {
         }
         viewRetriever = new RecyclerViewRetriever(view);
         positioner = new StickyHeaderPositioner(view);
-        positioner.setElevateHeaders(headerElevation);
+        positioner.setHeaderElevation(headerElevation);
         positioner.setListener(listener);
         if (headerPositions.size() > 0) {
             // Layout has already happened and header positions are cached. Catch positioner up.

--- a/stickyheaders/src/main/res/values/dimens.xml
+++ b/stickyheaders/src/main/res/values/dimens.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="default_elevation">5dp</dimen>
+
 </resources>


### PR DESCRIPTION
- Pass in a pixel value instead of a DP value for header elevation to match consistency with Android's `View.setElevation()` method and to allow clients to use a value from their app's `dimens` file so that elevation dimensions can be reused/standardized more easily.

- Remove `elevateHeaders()` to avoid differing behaviors for calling both `elevateHeaders()` and `setHeaderElevation()`. For example, as a client, is setting `setHeaderElevation(0)` the same as `elevateHeaders(false)? Exposing only one method to add or remove elevation avoids the confusion and potential conflicting behavior outcomes.

- Remove the `cachedElevation` field and elevation resolution helper methods since they're no longer necessary.